### PR TITLE
Update Get-LinkPerformance.ps1

### DIFF
--- a/AzureCT/PowerShell/AzureCT/Public/Get-LinkPerformance.ps1
+++ b/AzureCT/PowerShell/AzureCT/Public/Get-LinkPerformance.ps1
@@ -267,7 +267,7 @@
                     If ($FilePrefix -eq "P01") {If (($Line -like "*receiver*")) {$TPut = $Line.Substring(38,17).Trim()} #End If
                     }
                     Else {
-                        If (($Line -like "*SUM*" -and $Line -like "*receiver*")) {$TPut = $Line.Substring(38,17).Trim()} #End If
+                        If (($Line -like "*SUM*" -and $Line -like "*receiver*")) {$TPut = $Line.Substring(37,17).Trim()} #End If
                     } # End Else
                 } # End For
             } # End Try


### PR DESCRIPTION
It appears that when the total amount of data transferred using iPerf is great that a 1TB it will set the value for SUM to  ÿ%v½s:
 [SUM]   0.00-610.00 sec  0.00 ÿ%v½s  27.7 Gbits/sec                  receiver
When this happed the index starts at 37 instead of 38 so the the first number gets left off the display, for example: 

$filename = "C:\ACTTools\P17perf.log"
$Lines = Get-Content $FileName -ErrorAction Stop
$lines[70]
[SUM]   0.00-610.00 sec  0.00 ÿ%v½s  20.1 Gbits/sec                  receiver
$Lines[70].Substring(38,17).Trim()
0.1 Gbits/sec
$Lines[70].Substring(37,17).Trim()
20.1 Gbits/sec

Since you are triming I think if you set the index to start at 37 it should resolve the issue.